### PR TITLE
Add inventory edit/delete, API token and field validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Aplicación Flask responsive (móvil, tablet y escritorio) para registrar el estado de equipos y generar reportes.
 
+Campos obligatorios: **región**, **local** y **farmacia**.
+
 ## Funcionalidades
-- CRUD básico (crear y listar, cierre de reporte)
+- CRUD completo (crear, listar, editar, eliminar y cerrar reportes)
 - Búsqueda por local
 - Exportación CSV
-- API REST JSON para integración móvil / apps externas
+- API REST JSON para integración móvil / apps externas (requiere header `X-API-KEY` para operaciones de escritura)
 - PWA: manifest + service worker (cache básico offline)
 
 ## Requisitos
@@ -15,14 +17,15 @@ Python 3.10+
 ## Instalación
 ```bash
 pip install -r requirements.txt
+export API_TOKEN="mi-token"  # opcional, requerido para API de escritura
 python app.py
 ```
 Abrir: http://localhost:5000
 
 ## Endpoints API
 GET /api/inventario?search=
-POST /api/inventario (JSON)
-POST /api/inventario/<id>/cerrar
+POST /api/inventario (JSON, requiere `X-API-KEY`)
+POST /api/inventario/<id>/cerrar (requiere `X-API-KEY`)
 
 Ejemplo POST JSON:
 ```json
@@ -52,8 +55,7 @@ Ejemplo POST JSON:
 Instalable en Android/Chrome. Íconos vacíos de ejemplo: reemplazar en `static/icons/`.
 
 ## Próximos pasos sugeridos
-- Autenticación (roles)
-- Editar registros
-- Validaciones adicionales
+- Autenticación con roles
+- Validaciones adicionales (longitud de campos, rangos numéricos)
 - Tests automatizados
 - Cache más granular y estrategia background sync

--- a/inventario/__init__.py
+++ b/inventario/__init__.py
@@ -16,6 +16,7 @@ def create_app(test_config=None):
     db_path = os.path.join(Path(__file__).parent, 'data.sqlite')
     app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['API_TOKEN'] = os.environ.get('API_TOKEN')
 
     if test_config:
         app.config.update(test_config)

--- a/inventario/forms.py
+++ b/inventario/forms.py
@@ -12,8 +12,8 @@ class SearchForm(FlaskForm):
 class InventarioForm(FlaskForm):
     region = StringField('Región', validators=[DataRequired()])
     distrito = StringField('Distrito')
-    local = StringField('Local')
-    farmacia = StringField('Farmacia')
+    local = StringField('Local', validators=[DataRequired()])
+    farmacia = StringField('Farmacia', validators=[DataRequired()])
     puntos_venta = IntegerField('Pts Venta', validators=[Optional()])
     puntos_falla = IntegerField('Pts Falla', validators=[Optional()])
     monitor_cliente = SelectField('Monitor Cliente', choices=COMMON_CHOICES)

--- a/inventario/templates/inventario_list.html
+++ b/inventario/templates/inventario_list.html
@@ -14,7 +14,7 @@
 <div class="table-responsive">
   <table class="table table-sm table-striped align-middle small">
     <thead><tr>
-      <th>ID</th><th>Región</th><th>Distrito</th><th>Local</th><th>Farmacia</th><th>Pts Vta</th><th>Pts Falla</th><th>Cte</th><th>Asesor</th><th>Tecl</th><th>Esc</th><th>Mouse</th><th>Tecl PCM</th><th>UPS</th><th>Red</th><th>PinPad</th><th>Estado</th><th>Solución</th><th>Comentarios</th><th></th><th>Registro</th>
+      <th>ID</th><th>Región</th><th>Distrito</th><th>Local</th><th>Farmacia</th><th>Pts Vta</th><th>Pts Falla</th><th>Cte</th><th>Asesor</th><th>Tecl</th><th>Esc</th><th>Mouse</th><th>Tecl PCM</th><th>UPS</th><th>Red</th><th>PinPad</th><th>Estado</th><th>Solución</th><th>Comentarios</th><th>Acciones</th><th>Registro</th>
     </tr></thead>
     <tbody>
       {% for item in inventario %}
@@ -39,12 +39,19 @@
         <td>{{ item.fecha_solucion.strftime('%Y-%m-%d') if item.fecha_solucion else '' }}</td>
         <td style="max-width:200px">{{ item.comentarios }}</td>
         <td>
-          {% if item.estado_reporte != 'Cerrado' %}
-          <form method="POST" action="{{ url_for('web.inventario_cerrar', item_id=item.id) }}">
-            {{ form.csrf_token }}
-            <button class="btn btn-outline-success btn-sm">Cerrar</button>
-          </form>
-          {% endif %}
+          <div class="d-flex gap-1">
+            <a class="btn btn-outline-primary btn-sm" href="{{ url_for('web.inventario_editar', item_id=item.id) }}">Editar</a>
+            <form method="POST" action="{{ url_for('web.inventario_eliminar', item_id=item.id) }}" onsubmit="return confirm('¿Eliminar registro?');">
+              {{ form.csrf_token }}
+              <button class="btn btn-outline-danger btn-sm">Eliminar</button>
+            </form>
+            {% if item.estado_reporte != 'Cerrado' %}
+            <form method="POST" action="{{ url_for('web.inventario_cerrar', item_id=item.id) }}">
+              {{ form.csrf_token }}
+              <button class="btn btn-outline-success btn-sm">Cerrar</button>
+            </form>
+            {% endif %}
+          </div>
         </td>
         <td>{{ item.fecha_registro.strftime('%Y-%m-%d %H:%M') if item.fecha_registro else '' }}</td>
       </tr>


### PR DESCRIPTION
## Summary
- Require "local" and "farmacia" in inventory form
- Support editing and deleting inventory entries
- Secure API POST endpoints with optional `X-API-KEY`

## Testing
- `python -m py_compile app.py inventario/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689aadd64078833185fe37907abfd98b